### PR TITLE
Fix incorrect parser usage

### DIFF
--- a/src/engine/visitors/Expression.js
+++ b/src/engine/visitors/Expression.js
@@ -25,14 +25,15 @@ class ExpressionVisitor extends VtlVisitor {
 
 	visitNotExpr = ctx => new BooleanAlgebraVisitor(this).visit(ctx);
 
-	visitParenthesisExpr = ctx => this.visit(ctx.children[1]);
+	visitParenthesisExpr = ctx => this.visit(ctx.expr());
 
 	visitIfExpr = ctx => new IfThenElse(this).visit(ctx);
 
-	visitOptionalExpr = ctx => this.visit(ctx.children[0]);
-	visitStringFunctions = ctx => this.visit(ctx.children[0]);
-	visitFunctionsExpression = ctx => this.visit(ctx.children[0]);
-	visitGenericFunctions = ctx => this.visit(ctx.children[0]);
+	// TODO: Optional expression should handle missing values.
+	visitOptionalExpr = ctx => this.visit(ctx.expr());
+	visitStringFunctions = ctx => this.visit(ctx.stringOperators());
+	visitFunctionsExpression = ctx => this.visit(ctx.functions());
+	visitGenericFunctions = ctx => this.visit(ctx.genericOperators());
 
 	visitVarIdExpr = ctx => new VariableVisitor(this.bindings).visit(ctx);
 

--- a/src/engine/visitors/functions/Cast.js
+++ b/src/engine/visitors/functions/Cast.js
@@ -15,9 +15,9 @@ class CastVisitor extends VtlVisitor {
 	visitCastExpr = ctx => {
 		const { children } = ctx;
 
-		let opCtx = children[2];
-		let scalarTypeCtx = children[4];
-		let maskCtx = children[6];
+		let opCtx = ctx.expr();
+		let scalarTypeCtx = ctx.basicScalarType() || ctx.valueDomainName();
+		let maskCtx = ctx.STRING_CONSTANT();
 
 		const op = this.exprVisitor.visit(opCtx);
 		const mask = maskCtx ? maskCtx.getText() : undefined;

--- a/src/engine/visitors/functions/SubstrAtom.js
+++ b/src/engine/visitors/functions/SubstrAtom.js
@@ -17,9 +17,10 @@ class SubstrAtomVisitor extends VtlVisitor {
 			throw new Error('Invalid number of operands for function substr');
 
 		// Required because the grammar doesn't do it for us.
-		let operandCtx = children[2];
-		let startIndexCtx = children[4].children[0];
-		let lengthCtx = children[6].children[0];
+		let operandCtx = ctx.expr();
+
+		// TODO Grammar defines this as an unbounded array of expressions. Should be changed IMO
+		const [startIndexCtx, lengthCtx] = ctx.optionalExpr();
 
 		const operand = this.exprVisitor.visit(operandCtx);
 		const startIndex = this.exprVisitor.visit(startIndexCtx);


### PR DESCRIPTION
This issue fixes #9. In java and other OO languages, the generated parsers do not expose the children array directly. Instead, one should use the accessors that are enforcing types. 

Taking SubstrAtom as an example, in the parser definition, a method `optionalExpr(i)` is defined. 

https://github.com/InseeFr/VTL-Tools/blob/aacd8af07c014d38aeae2f696e0f0dcf81bc7a9d/src/antlr-tools/vtl-2.0-Insee/parser-vtl/VtlParser.js#L6416-L6424

The correct way of getting the sub-contexts is as such

https://github.com/InseeFr/VTL-Tools/blob/138db36b00aac6db33523f8ce0e8a86b331ad9f6/src/engine/visitors/functions/SubstrAtom.js#L19-L23